### PR TITLE
add unittest and coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+lib-cov
+coverage.html
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+
+pids
+logs
+results
+
+node_modules
+npm-debug.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
 .git*
+test/
+lib-cov/
+coverage.html
+.travis.yml
+Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.9
+  - 0.8

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+TESTS = test/*.test.js
+REPORTER = spec
+TIMEOUT = 1000
+JSCOVERAGE = ./node_modules/jscover/bin/jscover
+
+install:
+	@npm install
+
+test: install
+	@NODE_ENV=test ./node_modules/mocha/bin/mocha \
+		--reporter $(REPORTER) \
+		--timeout $(TIMEOUT) \
+		$(TESTS)
+
+test-cov: lib-cov
+	@CONNECT_DOMAIN_COV=1 $(MAKE) test
+	@CONNECT_DOMAIN_COV=1 $(MAKE) test REPORTER=html-cov > coverage.html
+
+lib-cov: install
+	@rm -rf $@
+	@$(JSCOVERAGE) lib $@
+
+.PHONY: test-cov test lib-cov

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/connect-domain');
+module.exports = process.env.CONNECT_DOMAIN_COV ? require('./lib-cov/connect-domain') : require('./lib/connect-domain');

--- a/lib/connect-domain.js
+++ b/lib/connect-domain.js
@@ -3,7 +3,7 @@
 	var domain = require('domain');
 
 	module.exports = function (handler) {
-		return function (req, res, next) {
+		return function domainMiddleware(req, res, next) {
 			var reqDomain = domain.create();
 
 			res.on('close', function () {
@@ -18,9 +18,7 @@
 				}
 			});
 
-			reqDomain.run(function () {
-				next();
-			});
+			reqDomain.run(next);
 		};
 	};
 }());

--- a/package.json
+++ b/package.json
@@ -9,5 +9,13 @@
 		"type": "git",
 		"url": "git://github.com/baryshev/connect-domain.git"
 	},
+	"devDependencies": {
+		"should": "*",
+		"connect": "*",
+		"jscover": "*",
+		"supertest": "*",
+		"pedding": "*",
+		"mocha": "*"
+	},
 	"engines" : { "node": ">= 0.8.0" }
 }


### PR DESCRIPTION
Hi, @baryshev , I want to use `connect-domain`, but I found out there is no unittests.

I try to add the test cases.

Also need to know `mocha` does not work with `domain` module normally. Please @see https://github.com/joyent/node/issues/4375 . I add some before hook to make `mocha` work with `domain`.
