### PR TITLE
remove "finish" event domain.dispose() codes.

### DIFF
--- a/lib/connect-domain.js
+++ b/lib/connect-domain.js
@@ -8,9 +8,10 @@ module.exports = function () {
 			reqDomain.dispose();
 		});
 
-		res.on('finish', function () {
-			reqDomain.dispose();
-		});
+		// Won't work with `connect.static()` middleware
+		// res.on('finish', function () {
+		// 	reqDomain.dispose();
+		// });
 
 		reqDomain.on('error', function (err) {
 			// Once a domain is disposed, further errors from the emitters in that set will be ignored.

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -45,12 +45,20 @@ describe('domain.test.js', function () {
 
   var app = connect()
   .use(connectDomain())
+  .use('/public', connect.static(__dirname + '/fixtures'))
   .use(normalHandler)
   .use(errorHandler);
 
   it('should GET / status 200', function (done) {
     request(app)
     .get('/')
+    .expect(200, done);
+  });
+
+  it('should GET /public/foo.js status 200', function (done) {
+    request(app)
+    .get('/public/foo.js')
+    .expect('console.log(\'bar\');')
     .expect(200, done);
   });
 

--- a/test/fixtures/foo.js
+++ b/test/fixtures/foo.js
@@ -1,0 +1,1 @@
+console.log('bar');


### PR DESCRIPTION
No need to call dispose() on 'finish' event.
