### PR TITLE
Remove useless function call for now

### DIFF
--- a/lib/connect-domain.js
+++ b/lib/connect-domain.js
@@ -4,13 +4,8 @@ module.exports = function () {
 	return function domainMiddleware(req, res, next) {
 		var reqDomain = domain.create();
 
-		res.on('close', function () {
-			reqDomain.dispose();
-		});
-
-		res.on('finish', function () {
-			reqDomain.dispose();
-		});
+		res.on('close', reqDomain.dispose);
+		res.on('finish', reqDomain.dispose);
 
 		reqDomain.on('error', function (err) {
 			// Once a domain is disposed, further errors from the emitters in that set will be ignored.


### PR DESCRIPTION
Hi,

I may be wrong but right now, both function calls wrapping reqDomain.dispose() seems unnecessary in this case, especially for each client request.

Regards,
